### PR TITLE
Fix library sorting under View by Folder Structure.

### DIFF
--- a/profile/georgia-reborn/scripts/Library/scripts/lib-populate.js
+++ b/profile/georgia-reborn/scripts/Library/scripts/lib-populate.js
@@ -2292,6 +2292,8 @@ class LibPopulate {
 	sort(data) {
 		if (!libSet.libSource && !lib.panel.multiProcess) return;
 		this.specialCharSort(data);
+		// View By Folder Structure is already sorted
+		if (libSet.viewBy === 10) return;
 		data.sort((a, b) => this.collator.compare(a.srt[2], b.srt[2]) || (a.srt[3] && !b.srt[3] ? 1 : 0));
 	}
 

--- a/profile/georgia-reborn/scripts/Library/scripts/lib-populate.js
+++ b/profile/georgia-reborn/scripts/Library/scripts/lib-populate.js
@@ -342,7 +342,7 @@ class LibPopulate {
 		if (level == 0) this.clearTree();
 
 		// * Apply View By Folder Hide if View by Folder Structure is active
-		if (libSet.viewBy === 10) lib.men.setViewByFolderHide(this.tree, libSet.viewByFolderHide);
+		if (lib.panel.folderView) lib.men.setViewByFolderHide(this.tree, libSet.viewByFolderHide);
 
 		br.forEach((v, i) => {
 			j = this.tree.length;
@@ -2293,7 +2293,7 @@ class LibPopulate {
 		if (!libSet.libSource && !lib.panel.multiProcess) return;
 		this.specialCharSort(data);
 		// View By Folder Structure is already sorted
-		if (libSet.viewBy === 10) return;
+		if (lib.panel.folderView) return;
 		data.sort((a, b) => this.collator.compare(a.srt[2], b.srt[2]) || (a.srt[3] && !b.srt[3] ? 1 : 0));
 	}
 


### PR DESCRIPTION
Fixes Library View: "View by Folder Structure" by avoiding an unnecessary sorting operation that breaks.

Note that this change is very brittle by relying upon the view's index. Given the way the code is put together, it seems like a more robust way to implement this would be to replace the constant with a reference to the last index.

It initially broke on my own install as I had disabled all views w/ Country (my music tagged via Musicbrainz doesn't have country tags populated in a helpful way).

I took a stab at viewing the debug output of the libSet object but got lost in the unwrapped console output as I don't usually do JS, let alone foobar development.

I believe this preexisting line of code could also be made more robust in a similar fashion:
https://github.com/TT-ReBORN/Georgia-ReBORN/blob/d885051403418be53ab3edfe013c343dd7a9426f/profile/georgia-reborn/scripts/Library/scripts/lib-populate.js#L345

Fixes #203.