### PR TITLE
Fix playback order button behavior

### DIFF
--- a/profile/georgia-reborn/scripts/Base/gr-buttons.js
+++ b/profile/georgia-reborn/scripts/Base/gr-buttons.js
@@ -513,21 +513,21 @@ class Button {
 
 		switch (plman.PlaybackOrder) {
 			case PlaybackOrder.Default:
-				this.setPlaybackOrder(this.btnImg.PlaybackRepeatPlaylist, 'repeatPlaylist', PlaybackOrder.RepeatPlaylist, 'Repeat (playlist)');
+				this.setPlaybackOrder(this.btnImg.PlaybackRepeatPlaylist, 'repeatPlaylist', PlaybackOrder.RepeatPlaylist);
 				break;
 
 			case PlaybackOrder.RepeatPlaylist:
-				this.setPlaybackOrder(this.btnImg.PlaybackRepeatTrack, 'repeatTrack', PlaybackOrder.RepeatTrack, 'Repeat (track)');
+				this.setPlaybackOrder(this.btnImg.PlaybackRepeatTrack, 'repeatTrack', PlaybackOrder.RepeatTrack);
 				break;
 			case PlaybackOrder.RepeatTrack:
-				this.setPlaybackOrder(this.btnImg.PlaybackShuffle, 'shuffle', PlaybackOrder.ShuffleTracks, 'Shuffle (tracks)');
+				this.setPlaybackOrder(this.btnImg.PlaybackShuffle, 'shuffle', PlaybackOrder.ShuffleTracks);
 				break;
 
 			case PlaybackOrder.Random:
 			case PlaybackOrder.ShuffleTracks:
 			case PlaybackOrder.ShuffleAlbums:
 			case PlaybackOrder.ShuffleFolders:
-				this.setPlaybackOrder(this.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default, 'Default');
+				this.setPlaybackOrder(this.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default);
 				break;
 		}
 
@@ -1395,14 +1395,12 @@ class Button {
 	 * Sets the button image, playback order preference, and foobar2000 playback order.
 	 * @param {GdiBitmap} imgValue - The value of this.btnImg.PlaybackDefault, this.btnImg.PlaybackRepeatTrack, or this.btnImg.PlaybackShuffle.
 	 * @param {string} prefValue - The value of 'default', 'repeatPlaylist', 'repeatTrack', or 'shuffle'.
-	 * @param {string} fbValue - The value of PlaybackOrder.Default, PlaybackOrder.RepeatPlaylist, PlaybackOrder.RepeatTrack, or PlaybackOrder.ShuffleTracks.
-	 * @param {string} cmd - The value of top menu Playback > Order.
+	 * @param {number} playbackOrderValue - The value of PlaybackOrder.Default, PlaybackOrder.RepeatPlaylist, PlaybackOrder.RepeatTrack, or PlaybackOrder.ShuffleTracks.
 	 */
-	setPlaybackOrder(imgValue, prefValue, fbValue, cmd) {
+	setPlaybackOrder(imgValue, prefValue, playbackOrderValue) {
 		this.btn.playbackOrder.img = imgValue;
 		grSet.playbackOrder = prefValue;
-		fb.PlaybackOrder = fbValue;
-		fb.RunMainMenuCommand(`Playback/Order/${cmd}`);
+		plman.PlaybackOrder = playbackOrderValue;
 	}
 
 	/**

--- a/profile/georgia-reborn/scripts/Base/gr-main.js
+++ b/profile/georgia-reborn/scripts/Base/gr-main.js
@@ -244,7 +244,7 @@ class MainUI {
 		/** @public @type {string} Displays the active playlist of the current playing track in the metadata grid in Details. */
 		this.playingPlaylist = '';
 		/** @public @type {number} Saves last playback order. */
-		this.lastPlaybackOrder = fb.PlaybackOrder;
+		this.lastPlaybackOrder = plman.PlaybackOrder;
 		/** @public @type {boolean} Is the song from a streaming source? */
 		this.isStreaming = false;
 		/** @public @type {boolean} Is the song playing from a CD? */

--- a/profile/georgia-reborn/scripts/Base/gr-menu-context.js
+++ b/profile/georgia-reborn/scripts/Base/gr-menu-context.js
@@ -192,28 +192,17 @@ class ContextMenus {
 			cm.separator();
 
 			const playbackOrderMenu = new ContextMenu('Playback order');
-			const playbackOrderModes = ['default', 'repeatPlaylist', 'repeatTrack', 'shuffle'];
+			const playbackOrderModes = [
+				{ id: 'default', value: PlaybackOrder.Default },
+				{ id: 'repeatPlaylist', value: PlaybackOrder.RepeatPlaylist },
+				{ id: 'repeatTrack', value: PlaybackOrder.RepeatTrack },
+				{ id: 'shuffle', value: PlaybackOrder.ShuffleTracks }
+			];
 			for (const playbackOrder of playbackOrderModes) {
-				playbackOrderMenu.appendItem(playbackOrder, () => {
-					switch (playbackOrder) {
-						case 'default':
-							grSet.playbackOrder = 'default';
-							fb.RunMainMenuCommand('Playback/Order/Default');
-							break;
-						case 'repeatPlaylist':
-							grSet.playbackOrder = 'repeatPlaylist';
-							fb.RunMainMenuCommand('Playback/Order/Repeat (playlist)');
-							break;
-						case 'repeatTrack':
-							grSet.playbackOrder = 'repeatTrack';
-							fb.RunMainMenuCommand('Playback/Order/Repeat (track)');
-							break;
-						case 'shuffle':
-							grSet.playbackOrder = 'shuffle';
-							fb.RunMainMenuCommand('Playback/Order/Shuffle (tracks)');
-							break;
-					}
-				}, { is_radio_checked: playbackOrder === grSet.playbackOrder });
+				playbackOrderMenu.appendItem(playbackOrder.id, () => {
+					plman.PlaybackOrder = playbackOrder.value;
+					grSet.playbackOrder = playbackOrder.id;
+				}, { is_radio_checked: playbackOrder.value === plman.PlaybackOrder });
 			}
 			cm.append(playbackOrderMenu);
 			cm.separator();

--- a/profile/georgia-reborn/scripts/Base/gr-menu.js
+++ b/profile/georgia-reborn/scripts/Base/gr-menu.js
@@ -4358,14 +4358,14 @@ class TopMenuOptions {
 
 		const clearAutoDownloadBio = () => {
 			grm.debug.autoDownloadBio = false;
-			grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default, 'Default');
+			grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default);
 			grm.ui.displayBiography = false;
 			grm.ui.clearTimer('autoDownloadBio');
 		};
 
 		const clearAutoDownloadLyrics = () => {
 			grm.debug.autoDownloadLyrics = false;
-			grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default, 'Default');
+			grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackDefault, 'default', PlaybackOrder.Default);
 			grm.ui.displayLyrics = false;
 			grm.ui.clearTimer('autoDownloadLyrics');
 		};
@@ -4384,7 +4384,7 @@ class TopMenuOptions {
 					}
 					clearAutoDownloadLyrics();
 					fb.Play();
-					grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackShuffle, 'shuffle', PlaybackOrder.ShuffleTracks, 'Shuffle (tracks)');
+					grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackShuffle, 'shuffle', PlaybackOrder.ShuffleTracks);
 					grm.ui.displayBiography = true;
 					grm.ui.autoDownloadBioTimer = setInterval(() => { fb.Next(); }, 6000);
 				});
@@ -4405,7 +4405,7 @@ class TopMenuOptions {
 					}
 					clearAutoDownloadBio();
 					fb.Play();
-					grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackRepeatPlaylist, 'repeatPlaylist', PlaybackOrder.RepeatPlaylist, 'Repeat (playlist)');
+					grm.button.setPlaybackOrder(grm.button.btnImg.PlaybackRepeatPlaylist, 'repeatPlaylist', PlaybackOrder.RepeatPlaylist);
 					grm.ui.displayLyrics = true;
 					grm.lyrics.initLyrics();
 					grm.ui.autoDownloadLyricsTimer = setInterval(() => { fb.Next(); }, 15000);


### PR DESCRIPTION
Fixes the playback order button by using `plman.PlaybackOrder` as the single source of truth when reading and updating foobar2000's playback order.

Previously the button read from `plman.PlaybackOrder`, but attempted to update `fb.PlaybackOrder` and then invoked menu commands. This made the behavior unreliable and inconsistent with the playback order change callback.

This keeps the existing cycle unchanged:

Default → Repeat playlist → Repeat track → Shuffle tracks → Default

Random and other shuffle modes are still treated as the existing `shuffle` UI state.